### PR TITLE
Invalid "Content-Disposition" header + handle missing partition

### DIFF
--- a/components/coredump/coredump.cpp
+++ b/components/coredump/coredump.cpp
@@ -38,7 +38,7 @@ void Coredump::setup() {
   }
 }
 
-bool Coredump::canHandle(AsyncWebServerRequest *request) {
+bool Coredump::canHandle(AsyncWebServerRequest *request) const {
   if (request->method() != HTTP_GET) {
     return false;
   }

--- a/components/coredump/coredump.cpp
+++ b/components/coredump/coredump.cpp
@@ -221,8 +221,8 @@ void Coredump::download_(AsyncWebServerRequest *request) {
 #ifdef ESPHOME_PROJECT_NAME
   response->addHeader("Content-Disposition", "attachment;filename=coredump-" ESPHOME_PROJECT_VERSION ".elf");
 #else
-  response->addHeader("Content-Disposition",
-                      ("attachment;filename=coredump-" + App.get_compilation_time() + ".elf").c_str());
+  auto content_disposition_value = "attachment;filename=\"coredump-" + App.get_compilation_time() + ".elf\"";
+  response->addHeader("Content-Disposition", content_disposition_value.c_str());
 #endif
 
   char buf[CHUNK_SIZE];

--- a/components/coredump/coredump.h
+++ b/components/coredump/coredump.h
@@ -32,6 +32,11 @@ class Coredump : public Component, public AsyncWebHandler {
   void erase_(AsyncWebServerRequest *request);
   void crash_(AsyncWebServerRequest *request);
   void download_(AsyncWebServerRequest *request);
+
+  void write_html_begin(AsyncWebServerRequest *request, const char *redirect_url = nullptr);
+
+ private:
+  bool partition_err = {false};
 };
 
 }  // namespace coredump

--- a/components/coredump/coredump.h
+++ b/components/coredump/coredump.h
@@ -16,7 +16,7 @@ class Coredump : public Component, public AsyncWebHandler {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::WIFI - 1.0f; }
 
-  bool canHandle(AsyncWebServerRequest *request) override;
+  bool canHandle(AsyncWebServerRequest *request) const override;
   void handleRequest(AsyncWebServerRequest *request) override;
 
  protected:


### PR DESCRIPTION
This merge request addresses two improvements:

1. Fix for Content-Disposition Header Pointer:
    
The pointer to the Content-Disposition header value was invalid due to the use of a temporary std::string being destroyed after calling c_str(). This has been corrected to ensure the pointer remains valid.

2. Improved OTA UX:

A check has been added to verify if the coredump partition exists in the partition table. This enhancement should improve the user experience during OTA updates by providing earlier feedback.

Note:
Both changes are included in this single PR for convenience. Apologies for combining them.