### PR TITLE
Add support for MJGDYK01YL dimmer variation to miot_ylkg0xyl and miot_ylxx0xyl_pair

### DIFF
--- a/components/miot_ylkg0xyl/README.md
+++ b/components/miot_ylkg0xyl/README.md
@@ -1,4 +1,4 @@
-# Yeelight Smart Bluetooth Wireless Dimmer Wall Light Switch Remote Control (YLKG08YL/YLKG07YL)
+# Yeelight Smart Bluetooth Wireless Dimmer Wall Light Switch Remote Control (YLKG08YL/YLKG07YL/MJGDYK01YL)
 
 Sample configuration:
 
@@ -12,6 +12,8 @@ sensor:
     mac_address: !secret device_mac_address
     # String, (Optional), device bind key. Will use "xiaomi_account" from "miot" if absent to automatically get the bindkey.
     bindkey: !secret device_bind_key
+    # Number (Optional), device product ID. Use 0x15CE for MJGDYK01YL, leave unset for YLKG07YL/YLKG08YL
+    # product_id: 0x15CE
     # List, Automation (Optional), The automation activated when you make specified action
     on_short_press:
       # List, Any automation

--- a/components/miot_ylkg0xyl/automation.h
+++ b/components/miot_ylkg0xyl/automation.h
@@ -20,6 +20,7 @@ enum MiotYLKG0XYLEvent {
 class MiotYLKG0XYLTrigger : public Trigger<uint8_t>, public miot::MiotListener {
  public:
   explicit MiotYLKG0XYLTrigger(MiotYLKG0XYLEvent event) : event_(event) { this->product_id_ = PRODUCT_ID_YLKG0xYL; }
+  MiotYLKG0XYLTrigger(MiotYLKG0XYLEvent event, uint16_t product_id) : event_(event) { this->product_id_ = product_id; }
 
  protected:
   MiotYLKG0XYLEvent event_;

--- a/components/miot_ylkg0xyl/miot_ylkg0xyl.cpp
+++ b/components/miot_ylkg0xyl/miot_ylkg0xyl.cpp
@@ -6,7 +6,19 @@ namespace miot_ylkg0xyl {
 
 static const char *const TAG = "miot_ylkg0xyl";
 
-void MiotYLKG0XYL::dump_config() { this->dump_config_(TAG, "YLKG07YL/YLKG08YL"); }
+void MiotYLKG0XYL::dump_config() {
+  const char* device_name;
+  switch (this->product_id_) {
+    case PRODUCT_ID_MJGDYK01YL:
+      device_name = "MJGDYK01YL";
+      break;
+    case PRODUCT_ID_YLKG0xYL:
+    default:
+      device_name = "YLKG07YL/YLKG08YL";
+      break;
+  }
+  this->dump_config_(TAG, device_name);
+}
 
 bool MiotYLKG0XYL::process_object_(const miot::BLEObject &obj) {
   switch (obj.id) {

--- a/components/miot_ylkg0xyl/miot_ylkg0xyl.h
+++ b/components/miot_ylkg0xyl/miot_ylkg0xyl.h
@@ -7,10 +7,12 @@ namespace esphome {
 namespace miot_ylkg0xyl {
 
 #define PRODUCT_ID_YLKG0xYL 0x03B6
+#define PRODUCT_ID_MJGDYK01YL 0x15CE
 
 class MiotYLKG0XYL : public miot::MiotComponent {
  public:
   MiotYLKG0XYL() { this->product_id_ = PRODUCT_ID_YLKG0xYL; }
+  MiotYLKG0XYL(uint16_t product_id) { this->product_id_ = product_id; }
 
   void dump_config() override;
 

--- a/components/miot_ylkg0xyl/sensor.py
+++ b/components/miot_ylkg0xyl/sensor.py
@@ -24,6 +24,7 @@ MiotYLKG0XYLEvent = miot_ylkg0xyl_ns.enum("MiotYLKG0XYLEvent")
 CONFIG_SCHEMA = cv.Schema(
     {
         # cv.GenerateID(): cv.declare_id(MiotYLKG0XYL),
+        cv.Optional(miot.CONF_PRODUCT_ID): cv.uint16_t,
         cv.Optional(CONF_ON_SHORT_PRESS): automation.validate_automation(
             cv.Schema(
                 {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MiotYLKG0XYLTrigger)}
@@ -59,8 +60,12 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def configure_event_trigger_(config, param, enum):
+    product_id = config.get(miot.CONF_PRODUCT_ID)
     for conf in config.get(param, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], enum)
+        if product_id is not None:
+            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], enum, product_id)
+        else:
+            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], enum)
         await miot.register_miot_device(trigger, config)
         await miot.setup_device_core_(trigger, config)
         await automation.build_automation(trigger, [(cg.uint8, "x")], conf)

--- a/components/miot_ylxx0xyl_pair/README.md
+++ b/components/miot_ylxx0xyl_pair/README.md
@@ -4,6 +4,7 @@ Supported models are:
 
 - Remote (YLYK01YL)
 - Dimmer (YLKG07YL/YLKG08YL)
+- Monitor Light Bar Remote (MJGDYK01YL)
 - Bathroom Heater Remote (YLYB01YL-BHFRC)
 - Fan Remote (YLYK01YL-VENFAN)
 - Ventilator Fan Remote (YLYK01YL-FANCL)
@@ -27,7 +28,7 @@ text_sensor:
     # Sesnor (Optional), sensor do display version.
     version:
       name: miot_ylxx0xyl_pair Version
-    # uint16 (Optional), product id to pair. defaults to 0, means auto for one of 0x0153, 0x03B6, 0x03BF, 0x04E6, 0x068E
+    # uint16 (Optional), product id to pair. defaults to 0, means auto for one of 0x0153, 0x03B6, 0x15CE, 0x03BF, 0x04E6, 0x068E
     #                    can be used to obtain beakonkey from unsupported devices.
     #product_id: 0
 ```

--- a/components/miot_ylxx0xyl_pair/miot_ylxx0xyl_pair.cpp
+++ b/components/miot_ylxx0xyl_pair/miot_ylxx0xyl_pair.cpp
@@ -20,6 +20,7 @@ static bool is_ylxx0xyl(uint16_t product_id) {
     case 0x03BF:  // YLYB01YL-BHFRC    Bathroom Heater Remote
     case 0x04E6:  // YLYK01YL-VENFAN   Fan Remote
     case 0x068E:  // YLYK01YL-FANCL    Ventilator Fan Remote
+    case 0x15CE:  // MJGDYK01YL        Monitor Light Bar 1S Remote
       return true;
   }
   return false;


### PR DESCRIPTION
**Motivation**
MJGDYK01YL is a dimmer that's shipped with Xiaomi Smart Monitor Light Bar 1S. 

There're several instructions around to flash this device with Tasmota[[1]](https://templates.blakadder.com/xiaomi_MJGJD02YL.html) or ESPHome, but none of them considers making a remote work. I decided I don't want to lose a remote, poked the device using your components, and turns out it's nearly identical to other Yeelight dimmers, only having a different `product_id`. 
Thus, with minimal changes to `miot_ylkg0xyl` I was able to make it work with my lamp. I have an end-to-end working ESPHome config that is currently targeting my fork: https://github.com/vanzi11a/esphome-xiaomi_monitor_light_bar_s1 

Using miot_ylxx0xyl_pair to extract bindkey also worked, but it took about three attempts to get past step 3.

**Changes**
- Add MJGDYK01YL as a variation of ylkg0xyl with a different product_id

