### PR TITLE
miot_client: support ESPHome 2026.2

### DIFF
--- a/components/miot_client/miot_client.cpp
+++ b/components/miot_client/miot_client.cpp
@@ -1,5 +1,6 @@
 
 #include "esphome/core/log.h"
+#include "esphome/core/version.h"
 #include "miot_client.h"
 
 namespace esphome {
@@ -226,7 +227,13 @@ esphome::ble_client::BLECharacteristic *MiotClient::get_char(const esp32_ble_tra
                                                              bool log_not_found) {
   auto res = this->parent()->get_characteristic(srv, chr);
   if (res == nullptr && log_not_found) {
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2026, 2, 0)
     ESP_LOGE(TAG, "Can't discover characteristics %s at service %s", chr.to_string().c_str(), srv.to_string().c_str());
+#else
+    char chr_uuid[esp32_ble::UUID_STR_LEN];
+    char srv_uuid[esp32_ble::UUID_STR_LEN];
+    ESP_LOGE(TAG, "Can't discover characteristics %s at service %s", chr.to_str(chr_uuid), srv.to_str(srv_uuid));
+#endif
   }
   return res;
 }


### PR DESCRIPTION
ESPHome 2026.2 moved ESPBTUUID into ble_device_base and replaced to_string() with to_str(char*), which writes into a caller-provided buffer. MiotClient::get_char() still used the removed to_string(), so every miot_* component failed to compile on ESPHome >= 2026.2:

  error: 'const ... ESPBTUUID' has no member named 'to_string'

Use the same ESPHOME_VERSION_CODE guard and VERSION_CODE(2026, 2, 0) threshold that vport/vport_ble.cpp already applies for this exact API change: before 2026.2 the original to_string() path stays intact, from 2026.2 on to_str() with a dedicated buffer per UUID is used. The edit only touches an error-log line, so there is no runtime behaviour change.

Verified with a full `esphome compile` of the miot_bwj_diffuser component on ESPHome 2026.8.2 / ESP32-C5 (ESP-IDF).